### PR TITLE
Removed duplicate content

### DIFF
--- a/pycrumbs.md
+++ b/pycrumbs.md
@@ -290,7 +290,6 @@
 * [Python Best Practice Patterns by Vladimir Keleshev](http://www.youtube.com/watch?v=GZNUfkVIHAY)
 
 ###Concurrency Patterns
-* [Wasps Nest Pattern](http://python.dzone.com/articles/wasps-nest-lock-free)
 * [Wasp's Nest: The Read-Copy-Update Pattern In Python](http://emptysqua.re/blog/wasps-nest-read-copy-update-python/)
 
 ##Concurrency and Distributed Systems


### PR DESCRIPTION
Not the same link, but the same content. Keeping the link to author's blog instead of dzone.
