### PR TITLE
Include site with online courses from different providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@
 * [Python Resources (All) - Codesters.org](http://web.archive.org/web/20160401215551/http://codesters.org/resource/topic/python/all/)
 * [Learn Python Online](https://www.codementor.io/learn-python-online)
 * [Programming Community Curated Python Tutorials & Courses](https://hackr.io/tutorials/learn-python)
+* [Online Courses](https://classpert.com/python-programming)
 
 ## Newsletters
 * [Pycoder's](http://pycoders.com/)

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@
 * [Python Resources (All) - Codesters.org](http://web.archive.org/web/20160401215551/http://codesters.org/resource/topic/python/all/)
 * [Learn Python Online](https://www.codementor.io/learn-python-online)
 * [Programming Community Curated Python Tutorials & Courses](https://hackr.io/tutorials/learn-python)
-* [Online Courses](https://classpert.com/python-programming)
+* [Classpert: Find and compare online courses from multiple providers](https://classpert.com/python-programming)
 
 ## Newsletters
 * [Pycoder's](http://pycoders.com/)


### PR DESCRIPTION
Hi Kirang,

we have recently launched classpert.com, a website that gathers online courses from several providers into a single page, so that students can find the course that best suits then. It includes free and paid courses, allowing users to filter by price, language, provider, and so on.
I've proposed to include a link to our Python programming course bundle. I think it can be helpful for learners who like to take video courses but don't know exactly where to start.
Best regards,

Igor Rocha